### PR TITLE
Enhance landing page branding and bios

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,25 @@ To use a different port:
 ```bash
 python3 serve.py --port 9000
 ```
+
+## Editing the Landing Page
+
+The site is entirely static. Update the content directly in the HTML and
+JavaScript files:
+
+* **index.html** – English version of the page.
+* **index_es.html** – Spanish version.
+
+Change headlines, taglines and copy by editing these files. The arrays in
+`js/main.js` control the rotating words in the hero section (`wordsEn` and
+`wordsEs`).
+
+Images are stored in the `images` folder. Replace the placeholder founder
+portraits or badges here while keeping the same file names so the markup does
+not change.
+
+The early‑access form submits to Formspree. To update the endpoint or fields,
+edit the `<form>` element in both HTML files.
+
+After making changes, run the server again and reload the browser to preview
+the updates.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1805,6 +1805,11 @@ a:hover {
 .what-we-do .block {
   max-width: 300px;
 }
+.what-we-do .product-logo {
+  width: 80px;
+  height: auto;
+  margin-bottom: 10px;
+}
 .trust {
   padding: 40px 20px;
   text-align: center;

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
     <button type="button" id="modal-close" class="modal-close"><i data-feather="x"></i><span class="hide-mobile">ESC</span></button>
     <div class="modal-content">
       <div class="success">
-        <a href="index.html" class="logo"><img src="images/logo-qorenz.svg" alt="logo"></a>
+        <a href="index.html" class="logo"><img src="images/logo-qorenz.png" alt="Qorenz Labs logo"></a>
         <h2 class="modal-title first-name" id="title-name"></h2>
         <p>Thanks! We'll get back to you within 1 business day.</p>
         <a href="index.html" class="button">Back home</a>
       </div>
       <div class="form-content">
-        <a href="index.html" class="logo"><img src="images/logo-qorenz.svg" alt="logo"></a>
+        <a href="index.html" class="logo"><img src="images/logo-qorenz.png" alt="Qorenz Labs logo"></a>
         <h2 class="modal-title">Request Early Access</h2>
         <p class="modal-subtitle">We're still in early stages and will contact you as soon as the beta opens.</p>
         <form class="form" action="https://formspree.io/f/xyz" method="POST">
@@ -50,7 +50,7 @@
     </div>
   </div>
   <div class="content">
-    <a href="index.html" class="logo"><img src="images/logo-qorenz.svg" alt="logo"></a>
+    <a href="index.html" class="logo"><img src="images/logo-qorenz.png" alt="Qorenz Labs logo"></a>
     <section class="hero">
       <h1 class="title">AI Insights. Real-Time.</h1>
       <h1 class="title shift clip"><span class="word-shift"><b class="is-visible">schools&nbsp;</b><b>parents</b><b>hospitals</b><b>plant managers</b></span></h1>
@@ -61,6 +61,7 @@
     <section class="what-we-do">
       <div class="grid">
         <div class="block">
+          <img src="images/logo-vikt.png" alt="Vikt logo" class="product-logo">
           <h3>Vikt</h3>
           <p>WhatsApp assistant that streams attendance & grade alerts and lets parents respond in real time.</p>
         </div>
@@ -86,12 +87,12 @@
       <div class="founder">
         <img src="https://via.placeholder.com/140" alt="Jorge Lezcano portrait">
         <h4>Jorge Lezcano</h4>
-        <p>Machine learning leader with a decade designing analytics for healthcare, mining and IIoT. Drives technical direction at Qorenz.</p>
+        <p>Jorge Lezcano is a machine-learning leader with a decade of experience in healthcare, mining, and IIoT. At Qorenz he spearheads engineering, ensuring data privacy and driving innovations that deliver measurable business impact for our partners.</p>
       </div>
       <div class="founder">
         <img src="https://via.placeholder.com/140" alt="Amalfi Lezcano portrait">
         <h4>Amalfi Lezcano</h4>
-        <p>Educator with over twenty years in K‑12 and higher ed. Shapes Vikt so teachers and parents communicate effortlessly.</p>
+        <p>Amalfi Lezcano brings twenty years in education administration and pedagogy. She shapes Vikt so teachers and parents collaborate easily. Her background in curriculum design and community outreach keeps our solutions centered on everyday classroom needs.</p>
       </div>
     </section>
     <footer class="footer">

--- a/index_es.html
+++ b/index_es.html
@@ -13,13 +13,13 @@
     <button type="button" id="modal-close" class="modal-close"><i data-feather="x"></i><span class="hide-mobile">ESC</span></button>
     <div class="modal-content">
       <div class="success">
-        <a href="index_es.html" class="logo"><img src="images/logo-qorenz.svg" alt="logo"></a>
+        <a href="index_es.html" class="logo"><img src="images/logo-qorenz.png" alt="Logo de Qorenz Labs"></a>
         <h2 class="modal-title first-name" id="title-name"></h2>
         <p>¡Gracias! Te contactaremos en un día hábil.</p>
         <a href="index_es.html" class="button">Volver</a>
       </div>
       <div class="form-content">
-        <a href="index_es.html" class="logo"><img src="images/logo-qorenz.svg" alt="logo"></a>
+        <a href="index_es.html" class="logo"><img src="images/logo-qorenz.png" alt="Logo de Qorenz Labs"></a>
         <h2 class="modal-title">Solicita Acceso Anticipado</h2>
         <p class="modal-subtitle">Aún estamos en etapas iniciales y te avisaremos cuando abra la beta.</p>
         <form class="form" action="https://formspree.io/f/xyz" method="POST">
@@ -50,7 +50,7 @@
     </div>
   </div>
   <div class="content">
-    <a href="index_es.html" class="logo"><img src="images/logo-qorenz.svg" alt="logo"></a>
+    <a href="index_es.html" class="logo"><img src="images/logo-qorenz.png" alt="Logo de Qorenz Labs"></a>
     <section class="hero">
       <h1 class="title">AI Insights. Real-Time.</h1>
       <h1 class="title shift clip"><span class="word-shift"><b class="is-visible">escuelas&nbsp;</b><b>padres</b><b>hospitales</b><b>gerentes de planta</b></span></h1>
@@ -61,6 +61,7 @@
     <section class="what-we-do">
       <div class="grid">
         <div class="block">
+          <img src="images/logo-vikt.png" alt="Logo de Vikt" class="product-logo">
           <h3>Vikt</h3>
           <p>Asistente en WhatsApp que envía alertas de asistencia y notas y permite que los padres respondan en tiempo real.</p>
         </div>
@@ -86,12 +87,12 @@
       <div class="founder">
         <img src="https://via.placeholder.com/140" alt="Retrato de Jorge Lezcano">
         <h4>Jorge Lezcano</h4>
-        <p>Líder de aprendizaje automático con diez años creando analíticas en salud, minería e IIoT. Dirige la parte técnica en Qorenz.</p>
+        <p>Jorge Lezcano es líder en aprendizaje automático con diez años de experiencia en salud, minería e IIoT. En Qorenz dirige ingeniería, asegura privacidad de datos y fomenta innovaciones que generan impacto medible para nuestros socios.</p>
       </div>
       <div class="founder">
         <img src="https://via.placeholder.com/140" alt="Retrato de Amalfi Lezcano">
         <h4>Amalfi Lezcano</h4>
-        <p>Educadora con más de veinte años en K‑12 y universidad. Asegura que Vikt facilite la comunicación entre profesores y padres.</p>
+        <p>Amalfi Lezcano acumula veinte años en administración educativa y pedagogía. Moldea Vikt para que docentes y padres colaboren sin fricción. Su experiencia en diseño curricular y vinculación comunitaria mantiene soluciones centradas en necesidades del aula.</p>
       </div>
     </section>
     <footer class="footer">


### PR DESCRIPTION
## Summary
- use PNG logos on both landing pages
- showcase Vikt logo in the features grid
- extend founder bios to 35 words each
- add product-logo styling

## Testing
- `python3 serve.py --port 9001`

------
https://chatgpt.com/codex/tasks/task_e_6850a235b168832f81124c4c6a222c95